### PR TITLE
Adds support for scoped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.tar
+.DS_Store

--- a/dist/leech.js
+++ b/dist/leech.js
@@ -51,8 +51,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 
 var composeImpl = function composeImpl(f, g) {
-  return function (x) {
-    return g(f(x));
+  return function () {
+    for (var _len = arguments.length, x = Array(_len), _key = 0; _key < _len; _key++) {
+      x[_key] = arguments[_key];
+    }
+
+    return g(f(x.join(' ')));
   };
 };
 
@@ -107,9 +111,15 @@ exports.default = function (opts /*: LeechOpts*/) {
   var downloaded = new _es6Set2.default();
 
   var getOutputFileName = function getOutputFileName(task) {
-    var re = /.*\/(.*)$/g;
-    var fileName = re.exec(task);
-    return fileName[1];
+    if (task.indexOf('@') === -1) {
+      var re = /.*\/(.*)$/g;
+      var fileName = re.exec(task);
+      return fileName[1];
+    } else {
+      var _re = /(@[^\/]+\/).*(?:\/(.*))$/g;
+      var _fileName = _re.exec(task);
+      return _fileName[1] + _fileName[2];
+    }
   };
 
   /*:: declare function Worker(url: string, cb: ((err:?string) => any)): any;*/
@@ -162,11 +172,15 @@ exports.default = function (opts /*: LeechOpts*/) {
 
   var toUrls = function toUrls(deps /*: DependencyMap*/) {
     return Object.getOwnPropertyNames(deps).map(function (id /*: string*/) {
-      return '' + opts.registry + id + '/' + deps[id];
+      return '' + opts.registry + uriencodeSpecific(id) + '/' + deps[id];
     }).filter(function (x) {
       return !downloaded.has(x);
     });
   };
+
+  function uriencodeSpecific(id) {
+    return id.replace(/\//g, '%2F');
+  }
 
   if (!packageJson.dependencies) {
     warn('No dependencies section in the specified input', opts.input);

--- a/lib/leech.js
+++ b/lib/leech.js
@@ -23,7 +23,7 @@ type LeechOpts = {
   decreaseTotal: P
 }
 
-const composeImpl = (f, g) => x => g(f(x))
+const composeImpl = (f, g) => (...x) => g(f(x.join(' ')))
 
 /* eslint-disable */
 type fn<T,U> = (x: T) => U;
@@ -75,10 +75,16 @@ export default (opts : LeechOpts) => {
 
   const downloaded = new Set()
 
-  const getOutputFileName = (task) => {
-    const re = /.*\/(.*)$/g
-    const fileName = re.exec(task)
-    return fileName[1]
+  const getOutputFileName = task => {
+    if (task.indexOf('@') === -1) {
+      const re = /.*\/(.*)$/g
+      const fileName = re.exec(task)
+      return fileName[1]
+    } else {
+      const re = /(@[^\/]+\/).*(?:\/(.*))$/g
+      const fileName = re.exec(task)
+      return fileName[1] + fileName[2]
+    }
   }
 
   declare function Worker(url: string, cb: ((err:?string) => any)): any;
@@ -131,11 +137,15 @@ export default (opts : LeechOpts) => {
   const toUrls = (deps: DependencyMap) => {
     return Object.getOwnPropertyNames(deps)
       .map((id: string) => {
-        return `${opts.registry}${id}/${deps[id]}`
+        return `${opts.registry}${uriencodeSpecific(id)}/${deps[id]}`
       })
-      .filter((x) => {
+      .filter(x => {
         return !downloaded.has(x)
       })
+  }
+
+  function uriencodeSpecific(id) {
+    return id.replace(/\//g, '%2F')
   }
 
   if (!packageJson.dependencies) {


### PR DESCRIPTION
The `toUrls` function generates urls like `registry/@foo/bar/^1.0.0` for a scoped like `@foo/bar`, which is invalid. `@foo/bar` should be partially uriencoded to `@foo%2Fbar`.

This PR fixes this and adds the scoped packages grouped by directory in the produced archive.

Also, it fixes an issue with logging not supporting multiple arguments.