### PR TITLE
Add option to store scoped packages in Artifactory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Ideal for mirroring a given set of packages to a private repository like JFrog A
 
 ```
     usage
-      $ npm-leech [-i package.json|package-lock.json] [-o foo.tar] [-c] [-d] [-D] 
+      $ npm-leech [-i package.json|package-lock.json] [-o foo.tar] [-a] [-c] [-d] [-D] 
 
     options
+      --artifactory, -a      Store scoped packages in a layout used by Artifactory
       --input, -i            source package.json or package-lock.json (default: ./package-lock.json)
       --output, -o           target tarballs tar (default: ./npm-tarballs.tar)
       --concurrency, -c      number of concurrent retrieval tasks for meta/pkg (default: 4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-leech",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-leech",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Utility to download dependent NPM tarballs for offline use.",
   "main": "src/index.js",
   "bin": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,11 @@ function getOutputFileName(task) {
       // (@[^\/]+\/)     = Match "@scope/"
       // (.*)            = Match "package
       // (\d*\.\d*\.\d*) = Match version
+      // [.-]            = Match any of '.' or '-'. Normally '.' here.
+      //                   Got a special case of name: react-docgen-typescript-plugin-1.0.2-canary.3c70e01.0.tgz
+      //                   Where the file name does not end on ".tgz" after version, but have a "-canary.*" text.
       // (.*)            = Match file extension, here "tgz"
-      const re = /(@[^\/]+\/).*(?:\/(.*)\-(\d*\.\d*\.\d*)\.(.*))$/g;
+      const re = /(@[^\/]+\/).*(?:\/(.*)\-(\d*\.\d*\.\d*)[.-](.*))$/g;
       const fileName = re.exec(task);
       // The output from the regexp:
       // fileName[1]: @scope/


### PR DESCRIPTION
Example running npm-leech on own source code using new option -a:
npx node src/index.js -a && tar tvf npm-tarballs.tar | grep "@types"
-rw-r--r-- 0/0            1735 2021-05-07 17:00 @types/events/-/@types/events-3.0.0.tgz
-rw-r--r-- 0/0            2918 2021-05-07 17:00 @types/minimatch/-/@types/minimatch-3.0.3.tgz

Previous layout:
npx node src/index.js && tar tvf npm-tarballs.tar | grep "@types"
-rw-r--r-- 0/0            1735 2021-05-07 17:03 @types/events-3.0.0.tgz
-rw-r--r-- 0/0            2918 2021-05-07 17:03 @types/minimatch-3.0.3.tgz

Artifactory has a file layout for scoped packages that is different from npmjs registry.
So when the tar file generated by npm-leech is imported into the web interface of Artifactory,
npm install of a scoped package using Artifactory as a registry will fail integrity check
if a non-scoped package with the same name and version exist. Artifactory seems to return
metadata for the scoped package, but fail to find the tar file and return the tar file from
the non-scoped version and npm client detect invalid checksum.

Several bug reports on this, here is one:
https://www.jfrog.com/jira/browse/RTFACT-7668

I manually renamed a scoped package in Artifactory that caused integrity error to the layout
that Artifactory expect and then npm install of that scoped package worked.

By making npm-leech store scoped packages with Artifactory layout, then the web interface bulk import
in Artifactory should work fine.